### PR TITLE
Replace MSE with L1/MAE losses and add `StandardMAE` for masked multitask regression

### DIFF
--- a/src/molecule/mol_hyperparameter_tuning.py
+++ b/src/molecule/mol_hyperparameter_tuning.py
@@ -54,7 +54,7 @@ def objective(trial, ml_dataset, edge_dim=edge_dim):
     results = train_and_evaluate_edge(
         model,
         optimizer,
-        torch.nn.MSELoss(),
+        torch.nn.L1Loss(),
         ml_dataset["train_loader"],
         ml_dataset["val_loader"],
         ml_dataset["test_loader"],

--- a/src/molecule/mol_losses.py
+++ b/src/molecule/mol_losses.py
@@ -49,3 +49,25 @@ class ContestWMAE(nn.Module):
         abs_err = (pred - target).abs() * mask
         per_sample = (abs_err * self.weights).sum(dim=1)
         return per_sample.mean()
+
+
+class StandardMAE(nn.Module):
+    """
+    Standard masked MAE for multitask regression.
+
+    Expects tensors shaped [batch, tasks] and a mask with the same shape
+    where labeled entries are 1 and missing entries are 0.
+    """
+
+    def __init__(self, inverse_transform=None) -> None:
+        super().__init__()
+        self.inverse_transform = inverse_transform
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        if self.inverse_transform is not None:
+            pred = self.inverse_transform(pred)
+            target = self.inverse_transform(target)
+
+        m = mask.float()
+        denom = m.sum().clamp_min(1.0)
+        return ((pred - target).abs() * m).sum() / denom

--- a/src/molecule/mol_pxr_challenge_train.py
+++ b/src/molecule/mol_pxr_challenge_train.py
@@ -22,7 +22,7 @@ from mol_functions import (
     randomize_smiles,
     advanced_smiles_to_graph,
 )
-from mol_losses import ContestWMAE
+from mol_losses import ContestWMAE, StandardMAE
 from mol_multitask_utils import (
     attach_multitask_targets,
     compute_scalers,
@@ -178,9 +178,9 @@ model = GINELayerUpgraded(
 
 optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4, weight_decay=1e-4)
 
-criterion_train = nn.L1Loss()#ContestWMAE()
-criterion_eval = nn.L1Loss()#ContestWMAE()
-criterion_test = nn.L1Loss()#ContestWMAE()
+criterion_train = StandardMAE()
+criterion_eval = StandardMAE()
+criterion_test = StandardMAE()
 
 results = train_and_evaluate_edge(
     model=model,

--- a/src/molecule/mol_torch_gnn_implementation.py
+++ b/src/molecule/mol_torch_gnn_implementation.py
@@ -237,7 +237,7 @@ def compare_pooling_methods(dataset, train_loader, val_loader, test_loader):
     lr = 0.001
     weight_decay = 5e-4
     epochs = 50
-    criterion = nn.MSELoss()
+    criterion = nn.L1Loss()
     # Initialize models with different pooling methods
     models = {
         "Mean Pooling": GCNLayer(in_channels, hidden_channels, out_channels),


### PR DESCRIPTION
### Motivation

- The training and evaluation pipelines should use L1/MAE-style losses for regression consistency with contest metrics and masked multitask targets.
- Provide a reusable masked MAE implementation to correctly aggregate multitask errors when labels are missing.

### Description

- Added a new `StandardMAE` loss class in `src/molecule/mol_losses.py` that implements a masked mean absolute error and supports an optional `inverse_transform`.
- Replaced `nn.MSELoss()` with `nn.L1Loss()` in `compare_pooling_methods` inside `src/molecule/mol_torch_gnn_implementation.py` to use L1 loss for model comparisons.
- Switched the hyperparameter tuning objective in `src/molecule/mol_hyperparameter_tuning.py` to use `torch.nn.L1Loss()` for training/evaluation during Optuna trials.
- Updated `src/molecule/mol_pxr_challenge_train.py` to import `StandardMAE` and use it for `criterion_train`, `criterion_eval`, and `criterion_test` instead of plain `nn.L1Loss()` (and removed the commented out `ContestWMAE` uses).

### Testing

- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9eae9308832eb88bfa870f958ce4)