### PR TITLE
Fix batched model call for inference and write test predictions to CSV

### DIFF
--- a/src/molecule/mol_pxr_challenge_train.py
+++ b/src/molecule/mol_pxr_challenge_train.py
@@ -296,7 +296,7 @@ predictions = []
 with torch.no_grad(): # disable gradient calculation for inference to save memory and computation 
     for batch in final_test_loader:
         batch = batch.to(device) # move the batch the same device as the model 
-        out = model(batch.x, batch.edge_index, batch.edge_attr, batch.u)
+        out = model(batch.x, batch.edge_index, batch.edge_attr, batch.batch, batch.u)
         predictions.append(out.detach().cpu())
         
 predictions = torch.cat(predictions, dim=0).squeeze(-1).numpy()
@@ -304,6 +304,8 @@ submission = pd.DataFrame({
     "Molecule Name": test_final["Molecule Name"],
     "pEC50": predictions,
 })
+submission.to_csv("pxr_challenge_submission.csv", index=False)
+logging.info("Saved blinded-test predictions to pxr_challenge_submission.csv")
 
 
 #if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Ensure the GNN receives the per-example batch indices during inference so global pooling operates correctly.  
- Persist blinded-test predictions to disk and emit a log message for downstream evaluation.

### Description
- Update model inference call to pass the batch vector by changing the call from `model(batch.x, batch.edge_index, batch.edge_attr, batch.u)` to `model(batch.x, batch.edge_index, batch.edge_attr, batch.batch, batch.u)`.  
- Write the generated submission dataframe to `pxr_challenge_submission.csv` using `submission.to_csv("pxr_challenge_submission.csv", index=False)` and add a `logging.info` message after saving.  

### Testing
- Performed an automated smoke inference run of the modified script on a small sample test split which executed the batched inference and produced `pxr_challenge_submission.csv` successfully.  
- No changes were made to existing unit tests and no additional unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef8b9add4832e97d7b59df6ab850f)